### PR TITLE
Display the StarGazers as an integer

### DIFF
--- a/controller/repositories.go
+++ b/controller/repositories.go
@@ -34,6 +34,11 @@ func GetRepo(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 	}
 }
 
+// IntValueFormatter is a ValueFormatter for int.
+func IntValueFormatter(v interface{}) string {
+  return fmt.Sprintf("%.0f", v)
+}
+
 // GetRepoChart returns the SVG chart for the given repository
 func GetRepoChart(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -104,6 +109,7 @@ func GetRepoChart(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 						A: 180,
 					},
 				},
+				ValueFormatter: IntValueFormatter,
 			},
 			Series: []chart.Series{series},
 		}


### PR DESCRIPTION
Add: integer ValueFormatter
The number of stargazers will always be an integer, so display it as such.

---

I don't speak Go, so this is a crude attempt at a fix.

I tried to change the global `DefaultFloatFormat` in `chart`, but either I'm not allowed to do that, or I failed to find the right Go syntax to do it.

Instead, this PR creates a `ValueFormatter` function and sets the Y-Axis' `ValueFormatter` member.