### PR TITLE
improve graph legibility

### DIFF
--- a/controller/repositories.go
+++ b/controller/repositories.go
@@ -67,8 +67,9 @@ func GetRepoChart(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 					R: 129,
 					G: 199,
 					B: 239,
-					A: 150,
+					A: 255,
 				},
+        StrokeWidth: 2,
 			},
 		}
 		for i, star := range stargazers {
@@ -87,12 +88,12 @@ func GetRepoChart(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 				NameStyle: chart.StyleShow(),
 				Style: chart.Style{
 					Show:        true,
-					StrokeWidth: 1,
+					StrokeWidth: 2,
 					StrokeColor: drawing.Color{
 						R: 85,
 						G: 85,
 						B: 85,
-						A: 180,
+						A: 255,
 					},
 				},
 			},
@@ -101,12 +102,12 @@ func GetRepoChart(cfg config.Config, cache *cache.Redis) http.HandlerFunc {
 				NameStyle: chart.StyleShow(),
 				Style: chart.Style{
 					Show:        true,
-					StrokeWidth: 1,
+					StrokeWidth: 2,
 					StrokeColor: drawing.Color{
 						R: 85,
 						G: 85,
 						B: 85,
-						A: 180,
+						A: 255,
 					},
 				},
 				ValueFormatter: IntValueFormatter,


### PR DESCRIPTION
- Set alpha to 255 (no transparency)
- Double the line thickness

The transparency made the graph a bit faint and hard to see.
Also, when the SVG is scaled down to fit on a webpage the thin lines
were anti-aliased making them still harder to see.