### PR TITLE
feat: round robin several github tokens

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,10 +7,10 @@ import (
 
 // Config configuration.
 type Config struct {
-	RedisURL       string `env:"REDIS_URL" envDefault:"redis://localhost:6379"`
-	GitHubTokens    []string `env:"GITHUB_TOKEN"`
-	GitHubPageSize int    `env:"GITHUB_PAGE_SIZE" envDefault:"100"`
-	Port           string `env:"PORT" envDefault:"3000"`
+	RedisURL       string   `env:"REDIS_URL" envDefault:"redis://localhost:6379"`
+	GitHubTokens   []string `env:"GITHUB_TOKENS"`
+	GitHubPageSize int      `env:"GITHUB_PAGE_SIZE" envDefault:"100"`
+	Port           string   `env:"PORT" envDefault:"3000"`
 }
 
 // Get the current Config.

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 // Config configuration.
 type Config struct {
 	RedisURL       string `env:"REDIS_URL" envDefault:"redis://localhost:6379"`
-	GitHubToken    string `env:"GITHUB_TOKEN"`
+	GitHubTokens    []string `env:"GITHUB_TOKEN"`
 	GitHubPageSize int    `env:"GITHUB_PAGE_SIZE" envDefault:"100"`
 	Port           string `env:"PORT" envDefault:"3000"`
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2,9 +2,13 @@ package github
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 
+	"github.com/apex/log"
 	"github.com/caarlos0/starcharts/config"
 	"github.com/caarlos0/starcharts/internal/cache"
+	"github.com/caarlos0/starcharts/internal/roundrobin"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,11 +20,11 @@ var ErrGitHubAPI = errors.New("failed to talk with github api")
 
 // GitHub client struct.
 type GitHub struct {
-	tokens    []string
+	tokens   roundrobin.RoundRobiner
 	pageSize int
 	cache    *cache.Redis
 
-	rateLimits, effectiveEtags prometheus.Counter
+	rateLimits, effectiveEtags, retryNewTokens prometheus.Counter
 }
 
 var rateLimits = prometheus.NewCounter(prometheus.CounterOpts{
@@ -35,17 +39,39 @@ var effectiveEtags = prometheus.NewCounter(prometheus.CounterOpts{
 	Name:      "effective_etag_uses_total",
 })
 
+var retryNewTokens = prometheus.NewCounter(prometheus.CounterOpts{
+	Namespace: "starcharts",
+	Subsystem: "github",
+	Name:      "next_token_retries",
+})
+
 func init() {
-	prometheus.MustRegister(rateLimits, effectiveEtags)
+	prometheus.MustRegister(rateLimits, effectiveEtags, retryNewTokens)
 }
 
 // New github client.
 func New(config config.Config, cache *cache.Redis) *GitHub {
 	return &GitHub{
-		tokens:          config.GitHubTokens,
+		tokens:         roundrobin.New(config.GitHubTokens),
 		pageSize:       config.GitHubPageSize,
 		cache:          cache,
 		rateLimits:     rateLimits,
 		effectiveEtags: effectiveEtags,
+		retryNewTokens: retryNewTokens,
 	}
+}
+
+func (gh *GitHub) authorizedDo(req *http.Request) (*http.Response, error) {
+	token, err := gh.tokens.Pick()
+	if err != nil || token == nil {
+		log.WithError(err).Error("couldn't get a valid token")
+		return http.DefaultClient.Do(req)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("token %s", token.Key()))
+	resp, err := http.DefaultClient.Do(req)
+	if resp.StatusCode == http.StatusUnauthorized {
+		token.Invalidate()
+	}
+	return resp, err
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -16,7 +16,7 @@ var ErrGitHubAPI = errors.New("failed to talk with github api")
 
 // GitHub client struct.
 type GitHub struct {
-	token    string
+	tokens    []string
 	pageSize int
 	cache    *cache.Redis
 
@@ -41,9 +41,8 @@ func init() {
 
 // New github client.
 func New(config config.Config, cache *cache.Redis) *GitHub {
-
 	return &GitHub{
-		token:          config.GitHubToken,
+		tokens:          config.GitHubTokens,
 		pageSize:       config.GitHubPageSize,
 		cache:          cache,
 		rateLimits:     rateLimits,

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -92,5 +92,5 @@ func (gh *GitHub) makeRepoRequest(ctx context.Context, name, etag string) (*http
 		req.Header.Add("If-None-Match", etag)
 	}
 
-	return gh.authorizedDo(req)
+	return gh.authorizedDo(req, 0)
 }

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -87,7 +87,7 @@ func (gh *GitHub) makeRepoRequest(ctx context.Context, name, etag string) (*http
 	if etag != "" {
 		req.Header.Add("If-None-Match", etag)
 	}
-	if gh.token != "" {
+	if len(gh.tokens) > 0 {
 		req.Header.Add("Authorization", fmt.Sprintf("token %s", gh.token))
 	}
 	return http.DefaultClient.Do(req)

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alicebob/miniredis"
 	"github.com/caarlos0/starcharts/config"
 	"github.com/caarlos0/starcharts/internal/cache"
+	"github.com/caarlos0/starcharts/internal/roundrobin"
 	"github.com/go-redis/redis"
 	"github.com/matryer/is"
 	"gopkg.in/h2non/gock.v1"
@@ -78,12 +79,12 @@ func TestRepoDetails_APIfailure(t *testing.T) {
 	t.Run("set error if api return 404", func(t *testing.T) {
 		is := is.New(t)
 		_, err := gt.RepoDetails(context.TODO(), "test/test")
-		is.True(err != nil) //Expected error
+		is.True(err != nil) // Expected error
 	})
 	t.Run("set error if api return 403", func(t *testing.T) {
 		is := is.New(t)
 		_, err := gt.RepoDetails(context.TODO(), "private/private")
-		is.True(err != nil) //Expected error
+		is.True(err != nil) // Expected error
 	})
 }
 
@@ -110,7 +111,7 @@ func TestRepoDetails_WithAuthToken(t *testing.T) {
 	cache := cache.New(rc)
 	defer cache.Close()
 	gt := New(config, cache)
-	gt.token = "12345"
+	gt.tokens = roundrobin.New([]string{"12345"})
 
 	t.Run("get repo with auth token", func(t *testing.T) {
 		is := is.New(t)

--- a/internal/github/repo_test.go
+++ b/internal/github/repo_test.go
@@ -32,6 +32,11 @@ func TestRepoDetails(t *testing.T) {
 	defer cache.Close()
 	gt := New(config, cache)
 
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
+
 	t.Run("get repo details from api", func(t *testing.T) {
 		is := is.New(t)
 		gock.New("https://api.github.com").
@@ -57,6 +62,11 @@ func TestRepoDetails(t *testing.T) {
 
 func TestRepoDetails_APIfailure(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
 
 	gock.New("https://api.github.com").
 		Get("/repos/test/test").
@@ -90,6 +100,11 @@ func TestRepoDetails_APIfailure(t *testing.T) {
 
 func TestRepoDetails_WithAuthToken(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
 
 	repo := Repository{
 		FullName:        "aasm/aasm",

--- a/internal/github/stars.go
+++ b/internal/github/stars.go
@@ -90,12 +90,8 @@ func (gh *GitHub) getStargazersPage(ctx context.Context, repo Repository, page i
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
-	case http.StatusUnauthorized:
-		log.Info("retrying with another token")
-		gh.retryNewTokens.Inc()
-		return gh.getStargazersPage(ctx, repo, page)
 	case http.StatusNotModified:
-		gh.effectiveEtags.Inc()
+		effectiveEtags.Inc()
 		log.Info("not modified")
 		err := gh.cache.Get(key, &stars)
 		if err != nil {
@@ -107,7 +103,7 @@ func (gh *GitHub) getStargazersPage(ctx context.Context, repo Repository, page i
 		}
 		return stars, err
 	case http.StatusForbidden:
-		gh.rateLimits.Inc()
+		rateLimits.Inc()
 		log.Warn("rate limit hit")
 		return stars, ErrRateLimit
 	case http.StatusOK:

--- a/internal/github/stars.go
+++ b/internal/github/stars.go
@@ -156,5 +156,5 @@ func (gh *GitHub) makeStarPageRequest(ctx context.Context, repo Repository, page
 		req.Header.Add("If-None-Match", etag)
 	}
 
-	return gh.authorizedDo(req)
+	return gh.authorizedDo(req, 0)
 }

--- a/internal/github/stars_test.go
+++ b/internal/github/stars_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alicebob/miniredis"
 	"github.com/caarlos0/starcharts/config"
 	"github.com/caarlos0/starcharts/internal/cache"
+	"github.com/caarlos0/starcharts/internal/roundrobin"
 	"github.com/go-redis/redis"
 	"github.com/matryer/is"
 	"gopkg.in/h2non/gock.v1"
@@ -98,7 +99,7 @@ func TestStargazers_EmptyResponseOnPagination(t *testing.T) {
 	defer cache.Close()
 	gt := New(config, cache)
 	gt.pageSize = 2
-	gt.token = "12345"
+	gt.tokens = roundrobin.New([]string{"12345"})
 
 	t.Run("get stargazers from api", func(t *testing.T) {
 		is := is.New(t)

--- a/internal/github/stars_test.go
+++ b/internal/github/stars_test.go
@@ -17,6 +17,11 @@ import (
 func TestStargazers(t *testing.T) {
 	defer gock.Off()
 
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
+
 	stargazers := []Stargazer{
 		{StarredAt: time.Now()},
 		{StarredAt: time.Now()},
@@ -64,6 +69,16 @@ func TestStargazers(t *testing.T) {
 func TestStargazers_EmptyResponseOnPagination(t *testing.T) {
 	defer gock.Off()
 
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
+
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 3999}})
+
 	stargazers := []Stargazer{
 		{StarredAt: time.Now()},
 		{StarredAt: time.Now()},
@@ -110,6 +125,11 @@ func TestStargazers_EmptyResponseOnPagination(t *testing.T) {
 
 func TestStargazers_APIFailure(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/rate_limit").
+		Reply(200).
+		JSON(rateLimit{rate{Limit: 5000, Remaining: 4000}})
 
 	repo1 := Repository{
 		FullName:        "test/test",

--- a/internal/roundrobin/roudrobin.go
+++ b/internal/roundrobin/roudrobin.go
@@ -14,7 +14,6 @@ type RoundRobiner interface {
 	Pick() (*Token, error)
 }
 
-
 // New round robin implementation with the given list of tokens.
 func New(tokens []string) RoundRobiner {
 	log.Debugf("creating round robin with %d tokens", len(tokens))

--- a/internal/roundrobin/roudrobin.go
+++ b/internal/roundrobin/roudrobin.go
@@ -1,26 +1,96 @@
+// Package roundrobin provides round robin invalidation-aware load balancing of github tokens.
 package roundrobin
 
-import "sync/atomic"
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 
-type RoundRobin struct {
-	items []string
-	next  int64
+	"github.com/apex/log"
+)
+
+// RoundRobiner can pick a token from a list of tokens.
+type RoundRobiner interface {
+	Pick() (*Token, error)
 }
 
-func New(items []string) *RoundRobin {
-	return &RoundRobin{items, 0}
+type realRoundRobin struct {
+	tokens []*Token
+	next   int64
 }
 
-func (rr *RoundRobin) Pick() string {
+// New round robin implementation with the given list of tokens.
+func New(tokens []string) RoundRobiner {
+	log.Debugf("creating round robin with %d tokens", len(tokens))
+	if len(tokens) == 0 {
+		return &noTokensRoundRobin{}
+	}
+	result := make([]*Token, 0, len(tokens))
+	for _, item := range tokens {
+		result = append(result, NewToken(item))
+	}
+	return &realRoundRobin{tokens: result}
+}
+
+func (rr *realRoundRobin) Pick() (*Token, error) {
+	return rr.doPick(0)
+}
+
+func (rr *realRoundRobin) doPick(try int) (*Token, error) {
+	if try > len(rr.tokens) {
+		return nil, fmt.Errorf("no valid tokens left")
+	}
 	idx := atomic.LoadInt64(&rr.next)
-	atomic.StoreInt64(&rr.next, (idx+1)%int64(len(rr.items)))
-	return rr.items[rr.next]
+	atomic.StoreInt64(&rr.next, (idx+1)%int64(len(rr.tokens)))
+	if pick := rr.tokens[idx]; pick.OK() {
+		log.Debugf("picked %s", pick.Key())
+		return pick, nil
+	}
+	return rr.doPick(try + 1)
 }
 
+type noTokensRoundRobin struct{}
+
+func (rr *noTokensRoundRobin) Pick() (*Token, error) {
+	return nil, nil
+}
+
+// Token is a github token.
 type Token struct {
 	token string
+	valid bool
+	lock  sync.RWMutex
 }
 
+// NewToken from its string representation.
+func NewToken(token string) *Token {
+	return &Token{
+		token: token,
+		valid: true,
+	}
+}
+
+// String returns the last 5 chars for the token.
 func (t *Token) String() string {
+	return t.token[len(t.token)-5:]
+}
+
+// Key returns the actual token.
+func (t *Token) Key() string {
 	return t.token
+}
+
+// OK returns true if the token is valid.
+func (t *Token) OK() bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.valid
+}
+
+// Invalidate invalidates the token.
+func (t *Token) Invalidate() {
+	log.Warnf("invalidated token '...%s'", t)
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.valid = false
 }

--- a/internal/roundrobin/roudrobin.go
+++ b/internal/roundrobin/roudrobin.go
@@ -1,0 +1,26 @@
+package roundrobin
+
+import "sync/atomic"
+
+type RoundRobin struct {
+	items []string
+	next  int64
+}
+
+func New(items []string) *RoundRobin {
+	return &RoundRobin{items, 0}
+}
+
+func (rr *RoundRobin) Pick() string {
+	idx := atomic.LoadInt64(&rr.next)
+	atomic.StoreInt64(&rr.next, (idx+1)%int64(len(rr.items)))
+	return rr.items[rr.next]
+}
+
+type Token struct {
+	token string
+}
+
+func (t *Token) String() string {
+	return t.token
+}

--- a/internal/roundrobin/roudrobin.go
+++ b/internal/roundrobin/roudrobin.go
@@ -14,10 +14,6 @@ type RoundRobiner interface {
 	Pick() (*Token, error)
 }
 
-type realRoundRobin struct {
-	tokens []*Token
-	next   int64
-}
 
 // New round robin implementation with the given list of tokens.
 func New(tokens []string) RoundRobiner {
@@ -30,6 +26,11 @@ func New(tokens []string) RoundRobiner {
 		result = append(result, NewToken(item))
 	}
 	return &realRoundRobin{tokens: result}
+}
+
+type realRoundRobin struct {
+	tokens []*Token
+	next   int64
 }
 
 func (rr *realRoundRobin) Pick() (*Token, error) {

--- a/internal/roundrobin/roudrobin.go
+++ b/internal/roundrobin/roudrobin.go
@@ -70,9 +70,9 @@ func NewToken(token string) *Token {
 	}
 }
 
-// String returns the last 5 chars for the token.
+// String returns the last 3 chars for the token.
 func (t *Token) String() string {
-	return t.token[len(t.token)-5:]
+	return t.token[len(t.token)-3:]
 }
 
 // Key returns the actual token.

--- a/internal/roundrobin/roundrobin_test.go
+++ b/internal/roundrobin/roundrobin_test.go
@@ -1,0 +1,50 @@
+package roundrobin
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestRoundRobin(t *testing.T) {
+	is := is.New(t)
+	var a, b, c, d int64
+	options := []string{"a", "b", "c", "d"}
+
+	rr := New(options)
+	var wg sync.WaitGroup
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			pick := rr.Pick()
+			switch pick {
+			case "a":
+				atomic.AddInt64(&a, 1)
+			case "b":
+				atomic.AddInt64(&b, 1)
+			case "c":
+				atomic.AddInt64(&c, 1)
+			case "d":
+				atomic.AddInt64(&d, 1)
+			default:
+				t.Error("invalid pick:", pick)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	for _, n := range []int64{a, b, c, d} {
+		requireWithinRange(t, n, 24, 26)
+	}
+	is.Equal(int64(100), a+b+c+d)
+}
+
+func requireWithinRange(t *testing.T, n, min, max int64) {
+	t.Helper()
+	is := is.New(t)
+	is.True(n >= min) // n should be at least min
+	is.True(n <= max) // n should be at most max
+}

--- a/internal/roundrobin/roundrobin_test.go
+++ b/internal/roundrobin/roundrobin_test.go
@@ -8,25 +8,104 @@ import (
 	"github.com/matryer/is"
 )
 
+const (
+	tokenA = "ghp_TokenA"
+	tokenB = "ghp_TokenB"
+	tokenC = "ghp_TokenC"
+	tokenD = "ghp_TokenD"
+)
+
+var tokens = []string{tokenA, tokenB, tokenC, tokenD}
+
 func TestRoundRobin(t *testing.T) {
 	is := is.New(t)
-	var a, b, c, d int64
-	options := []string{"a", "b", "c", "d"}
+	rr := New(tokens)
 
-	rr := New(options)
+	a, b, c, d := exercise(t, rr, 100)
+
+	for _, n := range []int64{a, b, c, d} {
+		requireWithinRange(t, n, 23, 27)
+	}
+	is.Equal(int64(100), a+b+c+d)
+}
+
+func TestRoundRobinWithInvalidatedKeys(t *testing.T) {
+	is := is.New(t)
+	rr := New(tokens)
+	invalidateN(t, rr, 2)
+
+	a, b, c, d := exercise(t, rr, 100)
+	is.Equal(a, int64(0))
+	is.Equal(b, int64(0))
+	requireWithinRange(t, c, 48, 52)
+	requireWithinRange(t, d, 48, 52)
+}
+
+func TestTokenString(t *testing.T) {
+	is := is.New(t)
+	is.Equal("okenA", NewToken(tokenA).String())
+	is.Equal("okenB", NewToken(tokenB).String())
+	is.Equal("okenC", NewToken(tokenC).String())
+	is.Equal("okenD", NewToken(tokenD).String())
+}
+
+func TestNoTokens(t *testing.T) {
+	is := is.New(t)
+	rr := New([]string{})
+	pick, err := rr.Pick()
+	is.True(pick == nil) // pick should not nil
+	is.NoErr(err)        // no error should be returned
+}
+
+func TestNoValidTokens(t *testing.T) {
+	is := is.New(t)
+	rr := New([]string{tokenA, tokenB})
+	invalidateN(t, rr, 2)
+
+	pick, err := rr.Pick()
+	is.True(pick == nil) // pick should be nil
+	is.True(err != nil)  // should err
+}
+
+func invalidateN(t *testing.T, rr RoundRobiner, n int) {
+	t.Helper()
+	is := is.New(t)
+	for i := 0; i < n; i++ {
+		pick, err := rr.Pick()
+		is.True(pick != nil) // pick should not be nil
+		is.NoErr(err)        // no error should be returned
+		pick.Invalidate()
+	}
+}
+
+func requireWithinRange(t *testing.T, n, min, max int64) {
+	t.Helper()
+	is := is.New(t)
+	is.True(n >= min) // n should be at least min
+	is.True(n <= max) // n should be at most max
+}
+
+func exercise(t *testing.T, rr RoundRobiner, n int) (int64, int64, int64, int64) {
+	t.Helper()
+	is := is.New(t)
+
+	var a, b, c, d int64
 	var wg sync.WaitGroup
+
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		go func() {
-			pick := rr.Pick()
-			switch pick {
-			case "a":
+			pick, err := rr.Pick()
+			is.True(pick != nil) // pick should not be nil
+			is.NoErr(err)        // no error should be returned
+			switch pick.Key() {
+			case tokenA:
 				atomic.AddInt64(&a, 1)
-			case "b":
+			case tokenB:
 				atomic.AddInt64(&b, 1)
-			case "c":
+			case tokenC:
 				atomic.AddInt64(&c, 1)
-			case "d":
+			case tokenD:
 				atomic.AddInt64(&d, 1)
 			default:
 				t.Error("invalid pick:", pick)
@@ -36,15 +115,5 @@ func TestRoundRobin(t *testing.T) {
 	}
 	wg.Wait()
 
-	for _, n := range []int64{a, b, c, d} {
-		requireWithinRange(t, n, 24, 26)
-	}
-	is.Equal(int64(100), a+b+c+d)
-}
-
-func requireWithinRange(t *testing.T, n, min, max int64) {
-	t.Helper()
-	is := is.New(t)
-	is.True(n >= min) // n should be at least min
-	is.True(n <= max) // n should be at most max
+	return a, b, c, d
 }

--- a/internal/roundrobin/roundrobin_test.go
+++ b/internal/roundrobin/roundrobin_test.go
@@ -43,10 +43,10 @@ func TestRoundRobinWithInvalidatedKeys(t *testing.T) {
 
 func TestTokenString(t *testing.T) {
 	is := is.New(t)
-	is.Equal("okenA", NewToken(tokenA).String())
-	is.Equal("okenB", NewToken(tokenB).String())
-	is.Equal("okenC", NewToken(tokenC).String())
-	is.Equal("okenD", NewToken(tokenD).String())
+	is.Equal("enA", NewToken(tokenA).String())
+	is.Equal("enB", NewToken(tokenB).String())
+	is.Equal("enC", NewToken(tokenC).String())
+	is.Equal("enD", NewToken(tokenD).String())
 }
 
 func TestNoTokens(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var static embed.FS
 
 func main() {
 	log.SetHandler(text.New(os.Stderr))
+	// log.SetLevel(log.DebugLevel)
 	config := config.Get()
 	ctx := log.WithField("port", config.Port)
 	options, err := redis.ParseURL(config.RedisURL)
@@ -50,7 +51,7 @@ func main() {
 		Methods(http.MethodGet).
 		HandlerFunc(controller.GetRepo(static, github, cache))
 
-		// generic metrics
+	// generic metrics
 	requestCounter := promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "starcharts",
 		Subsystem: "http",


### PR DESCRIPTION
for now we don't check their remaining rate limit, just invalidate them in memory if they are now invalid (401) and retry said request.

EDIT: now it checks the tokens and do not allow to use more than 50% their rate capacity. Also export a metric with the remaining of each token (label is only its last 5 chars) - let me know if you think this is a security issue (I don't think it is), if so I can hash it or something like that.

EDIT 2: last 3 chars