### PR TITLE
Correcting star count in the chart

### DIFF
--- a/controller/repositories.go
+++ b/controller/repositories.go
@@ -82,9 +82,10 @@ func GetRepoChart(gh *github.GitHub, cache *cache.Redis) http.Handler {
 				StrokeWidth: 2,
 			},
 		}
+
 		for i, star := range stargazers {
 			series.XValues = append(series.XValues, star.StarredAt)
-			series.YValues = append(series.YValues, float64(i))
+			series.YValues = append(series.YValues, float64(i+1))
 		}
 		if len(series.XValues) < 2 {
 			log.Info("not enough results, adding some fake ones")


### PR DESCRIPTION
Hi,
I've observed that the graph does not accurately display the number of stars.

Here's an example from a repository with a low star count:
<img width="90%" src="https://github.com/caarlos0/starcharts/assets/10252305/dbc09f95-5444-4ab4-8e48-2076fe4764b8">
