### PR TITLE
Optimize SVG output

### DIFF
--- a/internal/chart/svg/tag_builder.go
+++ b/internal/chart/svg/tag_builder.go
@@ -22,11 +22,11 @@ func (t *TagBuilder) Render(io io.Writer) {
 		if err != nil {
 			panic(err)
 		}
-	}
-
-	_, err := fmt.Fprintf(io, "<%s %s>%s</%s>", t.tag, t.attrString(), t.content.String(), t.tag)
-	if err != nil {
-		panic(err)
+	} else {
+		_, err := fmt.Fprintf(io, "<%s %s>%s</%s>", t.tag, t.attrString(), t.content.String(), t.tag)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/internal/chart/svg/text.go
+++ b/internal/chart/svg/text.go
@@ -3,8 +3,6 @@ package svg
 func Text() *TagBuilder {
 	return &TagBuilder{
 		tag: "text",
-		attributes: map[string]string{
-			"xmlns": "http://www.w3.org/2000/svg",
-		},
+		attributes: map[string]string{},
 	}
 }


### PR DESCRIPTION
First of all, thanks for this great project!

# Description
This PR removes duplicate tags if there is no content in them. It also removes the `xmlns` attribute from the `text` tags because it's not needed AFAIK. In total, the SVG size is roughly halved.

# File Comparison
This is the original (formatted) file
![starcharts_fmt](https://github.com/user-attachments/assets/7613a09e-19a9-4c60-a39b-bc6e6aa703e9)
and this is the optimized (formatted) file
![starcharts_fix_fmt](https://github.com/user-attachments/assets/f16b3a4a-249d-48af-9eaf-8d2d451c4027)
Both are formatted to make them easier to compare (after saving), but nothing has been changed after the generation except for whitespace.
Also, ignore the 2021-10-12 vs 2021-10-13 date difference. That might be because I'm using slightly different go dependencies, or I can't generate both images at *exactly* the same time.

P.S.: The way Inkscape optimizes SVGs is also interesting, but this exceeds my basic knowledge of SVGs. See this file for comparison
![starcharts_opt](https://github.com/user-attachments/assets/4c5e2973-1d6b-4768-8fef-36cb4dd2cd86)

